### PR TITLE
fix(employee-dashboard): resolve camera retry, profile photo, and lea…

### DIFF
--- a/laravel-app/app/Http/Controllers/ProfileController.php
+++ b/laravel-app/app/Http/Controllers/ProfileController.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\View\View;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 
 class ProfileController extends Controller
@@ -50,6 +51,54 @@ public function update(ProfileUpdateRequest $request): RedirectResponse
     return Redirect::route('profile.edit')->with('status', 'profile-updated');
 }
 
+
+    /**
+     * Serve the authenticated user's profile photo with hybrid fallback.
+     * Self-caching: fetches from Flask once, saves to Laravel storage permanently.
+     */
+    public function photo(Request $request)
+    {
+        $user = $request->user();
+
+        // Tier 1: already has an uploaded photo
+        if ($user->foto && Storage::disk('public')->exists($user->foto)) {
+            return redirect(asset('storage/' . $user->foto));
+        }
+
+        // Tier 2: has face data — fetch from Flask, self-cache
+        if ($user->has_face_data && $user->username) {
+            $flaskUrl = config('services.flask.url', env('FLASK_SERVICE_URL', 'http://face-service:5000'));
+
+            try {
+                $listResponse = Http::timeout(5)->get("{$flaskUrl}/face-dataset/{$user->username}");
+
+                if ($listResponse->successful()) {
+                    $photos = $listResponse->json('photos', []);
+
+                    if (!empty($photos)) {
+                        $photoPath = $photos[0]['photo_url'];
+                        $photoResponse = Http::timeout(5)->get("{$flaskUrl}{$photoPath}");
+
+                        if ($photoResponse->successful()) {
+                            $filename = 'profile/' . $user->username . '_' . time() . '.jpg';
+                            Storage::disk('public')->put($filename, $photoResponse->body());
+
+                            $user->update(['foto' => $filename]);
+
+                            return response($photoResponse->body())
+                                ->header('Content-Type', 'image/jpeg')
+                                ->header('Cache-Control', 'private, no-store');
+                        }
+                    }
+                }
+            } catch (\Exception $e) {
+                // Fall through to default
+            }
+        }
+
+        // Tier 3: default avatar
+        return response()->file(public_path('img/default-avatar.svg'));
+    }
 
     /**
      * Delete the user's account.

--- a/laravel-app/app/Http/Requests/ProfileUpdateRequest.php
+++ b/laravel-app/app/Http/Requests/ProfileUpdateRequest.php
@@ -16,8 +16,8 @@ class ProfileUpdateRequest extends FormRequest
     public function rules(): array
     {
         return [
-        'name' => ['required', 'string', 'max:255'],
-        'email' => ['required', 'email'],
+        'name' => ['sometimes', 'required', 'string', 'max:255'],
+        'email' => ['sometimes', 'required', 'email'],
         'jabatan' => ['nullable', 'string', 'max:255'],
         'foto' => ['nullable', 'image', 'max:2048'],
         ];

--- a/laravel-app/app/Models/User.php
+++ b/laravel-app/app/Models/User.php
@@ -63,4 +63,23 @@ class User extends Authenticatable
     {
         return $this->belongsTo(WorkShift::class);
     }
+
+    /**
+     * Get the profile photo URL with hybrid fallback:
+     * 1. Manual upload (foto column)
+     * 2. Face dataset proxy (self-caching)
+     * 3. Default SVG avatar
+     */
+    public function getProfilePhotoUrlAttribute(): string
+    {
+        if ($this->foto) {
+            return asset('storage/' . $this->foto);
+        }
+
+        if ($this->has_face_data && $this->username) {
+            return route('profile.photo');
+        }
+
+        return asset('img/default-avatar.svg');
+    }
 }

--- a/laravel-app/public/img/default-avatar.svg
+++ b/laravel-app/public/img/default-avatar.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" fill="none">
+  <rect width="128" height="128" rx="24" fill="#e2e8f0"/>
+  <circle cx="64" cy="48" r="20" fill="#94a3b8"/>
+  <path d="M64 76c-22 0-40 12-40 28v4h80v-4c0-16-18-28-40-28z" fill="#94a3b8"/>
+</svg>

--- a/laravel-app/resources/views/admin/absence.blade.php
+++ b/laravel-app/resources/views/admin/absence.blade.php
@@ -86,11 +86,7 @@
                                 <td class="px-6 py-4">
                                     <div class="flex items-center gap-3">
                                         <div class="w-10 h-10 rounded-full bg-gray-200 flex items-center justify-center overflow-hidden">
-                                             @if($izin->user->foto)
-                                                <img src="{{ asset('storage/' . $izin->user->foto) }}" class="w-full h-full object-cover">
-                                            @else
-                                                <span class="material-icons-round text-gray-400">person</span>
-                                            @endif
+                                             <img src="{{ $izin->user->profile_photo_url }}" class="w-full h-full object-cover">
                                         </div>
                                         <div>
                                             <p class="font-bold text-sm text-gray-900 dark:text-white">{{ $izin->user->name }}</p>

--- a/laravel-app/resources/views/admin/employees/index.blade.php
+++ b/laravel-app/resources/views/admin/employees/index.blade.php
@@ -61,14 +61,8 @@
 
                     <div class="relative mb-6">
                         <div class="mx-auto h-20 w-20 overflow-hidden rounded-2xl bg-slate-100 shadow-md">
-                            @if($employee->foto)
-                                <img src="{{ asset('storage/' . $employee->foto) }}" alt="{{ $employee->name }}"
+                            <img src="{{ $employee->profile_photo_url }}" alt="{{ $employee->name }}"
                                     class="h-full w-full object-cover">
-                            @else
-                                <div class="flex h-full w-full items-center justify-center bg-slate-200 text-slate-400">
-                                    <span class="material-icons-round text-4xl">person</span>
-                                </div>
-                            @endif
                         </div>
                     </div>
 
@@ -104,7 +98,7 @@
                             data-role="{{ $employee->role }}"
                             data-jabatan="{{ $employee->jabatan }}"
                             data-username="{{ $employee->username }}"
-                            data-foto-url="{{ $employee->foto ? asset('storage/' . $employee->foto) : '' }}"
+                            data-foto-url="{{ $employee->profile_photo_url }}"
                             @click="openFaceModalFromDataset($el.dataset)"
                             class="flex w-full items-center justify-center gap-2 rounded-xl border border-primary/40 bg-primary/15 px-3 py-2 text-xs font-bold text-slate-700 transition hover:bg-primary/30 dark:text-slate-100">
                             <span class="material-icons-round text-base">face_retouching_natural</span>

--- a/laravel-app/resources/views/dashboard.blade.php
+++ b/laravel-app/resources/views/dashboard.blade.php
@@ -331,7 +331,7 @@
                 </div>
 
                 <div class="flex justify-end gap-3 pt-4">
-                    <button type="button" @click="show = false"
+                    <button type="button" @click="closeModal()"
                         class="rounded-lg px-4 py-2 text-sm font-medium text-slate-600 dark:text-slate-400 transition hover:bg-slate-100 dark:hover:bg-slate-800">
                         Batal
                     </button>
@@ -364,13 +364,12 @@
                     x-text="new Date().toLocaleTimeString('id-ID', { hour: '2-digit', minute: '2-digit' }) + ' WIB'"></div>
             </div>
 
-            <template x-if="step === 'capture'">
-                <div>
+            <div x-show="step === 'capture'">
                     <div class="grid grid-cols-1 gap-5 lg:grid-cols-2">
                         <div class="space-y-4">
                             <div class="relative aspect-square overflow-hidden rounded-2xl border-2 border-dashed border-slate-300 dark:border-slate-600 bg-slate-100 dark:bg-slate-800">
                                 <video x-show="!capturedPreview" x-ref="video" class="h-full w-full scale-x-[-1] object-cover" autoplay playsinline muted></video>
-                                <img x-show="capturedPreview" :src="capturedPreview" alt="Hasil foto absensi" class="h-full w-full object-cover" />
+                                <img x-show="capturedPreview" :src="capturedPreview" alt="Hasil foto absensi" class="h-full w-full scale-x-[-1] object-cover" />
                                 <canvas x-ref="canvas" class="hidden"></canvas>
 
                                 <div x-show="!stream && !loading && !capturedPreview"
@@ -455,11 +454,9 @@
                             </div>
                         </div>
                     </div>
-                </div>
-            </template>
+            </div>
 
-            <template x-if="step === 'result'">
-                <div class="space-y-4">
+            <div x-show="step === 'result'" class="space-y-4">
                     <div class="rounded-2xl border border-slate-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-800 p-4">
                         <div class="mx-auto w-full max-w-2xl rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-card-dark shadow-sm">
                             <div class="border-b border-slate-200 dark:border-slate-700 px-4 py-3 text-center text-lg font-bold text-slate-800 dark:text-white"
@@ -467,7 +464,7 @@
 
                             <div class="space-y-4 p-4">
                                 <div class="relative h-56 overflow-hidden rounded-lg bg-slate-700">
-                                    <img x-show="capturedPreview" :src="capturedPreview" alt="Capture result" class="h-full w-full object-cover opacity-70" />
+                                    <img x-show="capturedPreview" :src="capturedPreview" alt="Capture result" class="h-full w-full scale-x-[-1] object-cover opacity-70" />
                                     <div class="absolute inset-0 flex items-center justify-center">
                                         <div class="relative h-36 w-36 rounded-2xl border-4"
                                             :class="attendanceResult?.success ? 'border-emerald-400' : 'border-red-400'">
@@ -550,8 +547,7 @@
                             Tutup
                         </button>
                     </div>
-                </div>
-            </template>
+            </div>
         </div>
     </x-pastel-modal>
 

--- a/laravel-app/resources/views/izin/index.blade.php
+++ b/laravel-app/resources/views/izin/index.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.absensi')
 
 @section('content')
-    <div class="space-y-6">
+    <div x-data class="space-y-6">
         <!-- HEADER -->
         <div class="flex justify-between items-center">
             <div>

--- a/laravel-app/resources/views/layouts/admin.blade.php
+++ b/laravel-app/resources/views/layouts/admin.blade.php
@@ -88,12 +88,8 @@
                 class="mb-6 p-4 bg-slate-50 dark:bg-slate-800/50 rounded-2xl border border-slate-100 dark:border-slate-800 flex items-center gap-3">
                 <div
                     class="w-10 h-10 rounded-full bg-slate-200 dark:bg-slate-700 flex items-center justify-center overflow-hidden">
-                    @if(Auth::user()->foto)
-                        <img alt="Profile" class="w-full h-full object-cover"
-                            src="{{ asset('storage/' . Auth::user()->foto) }}" />
-                    @else
-                        <span class="material-icons-round text-slate-500">person</span>
-                    @endif
+                    <img alt="Profile" class="w-full h-full object-cover"
+                            src="{{ Auth::user()->profile_photo_url }}" />
                 </div>
                 <div class="overflow-hidden">
                     <h3 class="font-bold text-slate-900 dark:text-white text-sm truncate uppercase">

--- a/laravel-app/resources/views/profile/edit.blade.php
+++ b/laravel-app/resources/views/profile/edit.blade.php
@@ -32,7 +32,7 @@
                     <div class="flex w-full flex-col items-center gap-3 md:w-auto">
                         <div class="relative">
                             <div class="h-40 w-40 overflow-hidden rounded-2xl border-2 border-dashed border-slate-300 bg-slate-100">
-                                <img src="{{ $user->foto ? asset('storage/' . $user->foto) : asset('img/default.png') }}" alt="Foto Profil"
+                                <img src="{{ $user->profile_photo_url }}" alt="Foto Profil"
                                     class="h-full w-full object-cover">
                             </div>
 

--- a/laravel-app/routes/web.php
+++ b/laravel-app/routes/web.php
@@ -45,6 +45,9 @@ Route::middleware(['auth'])->group(function () {
     Route::delete('/profile', [ProfileController::class, 'destroy'])
         ->name('profile.destroy');
 
+    Route::get('/profile/photo', [ProfileController::class, 'photo'])
+        ->name('profile.photo');
+
     Route::get('/profile/password', [PasswordController::class, 'edit'])
         ->name('password.edit');
 


### PR DESCRIPTION
…ve modal bugs

- Fix attendance modal camera retry crash by replacing x-if with x-show so the video element stays in DOM across step transitions
- Fix captured photo appearing flipped by adding scale-x-[-1] to preview images
- Add hybrid profile photo system with 3-tier fallback: manual upload, self-caching face dataset proxy from Flask, and default SVG avatar
- Fix profile photo upload form failing validation by making name/email fields sometimes|required in ProfileUpdateRequest
- Fix profile photo cache leak across user sessions (Cache-Control: private)
- Add profile_photo_url accessor to User model and update all Blade templates
- Fix leave request modal not opening on izin page (missing x-data scope)
- Fix leave modal cancel button not closing (wrong reactive property name)