### PR TITLE
fix(profile-photo): persist storage and restore employee avatar rende…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,8 @@ services:
       - ./laravel-app/resources:/var/www/html/resources
       - ./laravel-app/public:/var/www/html/public
       - ./laravel-app/database:/var/www/html/database
+      # Persist uploaded files (profile photos, etc.) across container restarts
+      - ./laravel-app/storage:/var/www/html/storage
       # Config files
       - ./laravel-app/package.json:/var/www/html/package.json
       - ./laravel-app/vite.config.js:/var/www/html/vite.config.js

--- a/laravel-app/Dockerfile
+++ b/laravel-app/Dockerfile
@@ -54,8 +54,12 @@ RUN chown -R www-data:www-data /var/www/html/storage /var/www/html/bootstrap/cac
 RUN a2enmod rewrite
 COPY docker/apache.conf /etc/apache2/sites-available/000-default.conf
 
+# Copy entrypoint script (ensures storage:link on every startup)
+COPY docker/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
 # Expose port 80
 EXPOSE 80
 
-# Start Apache
-CMD ["apache2-foreground"]
+# Use entrypoint that creates storage symlink then starts Apache
+CMD ["/usr/local/bin/docker-entrypoint.sh"]

--- a/laravel-app/app/Http/Controllers/ProfileController.php
+++ b/laravel-app/app/Http/Controllers/ProfileController.php
@@ -53,24 +53,33 @@ public function update(ProfileUpdateRequest $request): RedirectResponse
 
 
     /**
-     * Serve the authenticated user's profile photo with hybrid fallback.
+     * Serve a user's profile photo with hybrid fallback.
+     * Accepts optional user ID so admins can view any employee's photo.
      * Self-caching: fetches from Flask once, saves to Laravel storage permanently.
      */
-    public function photo(Request $request)
+    public function photo(Request $request, ?int $user = null)
     {
-        $user = $request->user();
+        // Resolve target user: if ID provided and requester is admin, look up that user
+        if ($user && $request->user()->role === 'admin') {
+            $targetUser = \App\Models\User::find($user);
+            if (!$targetUser) {
+                return response()->file(public_path('img/default-avatar.svg'));
+            }
+        } else {
+            $targetUser = $request->user();
+        }
 
         // Tier 1: already has an uploaded photo
-        if ($user->foto && Storage::disk('public')->exists($user->foto)) {
-            return redirect(asset('storage/' . $user->foto));
+        if ($targetUser->foto && Storage::disk('public')->exists($targetUser->foto)) {
+            return redirect(asset('storage/' . $targetUser->foto));
         }
 
         // Tier 2: has face data — fetch from Flask, self-cache
-        if ($user->has_face_data && $user->username) {
+        if ($targetUser->has_face_data && $targetUser->username) {
             $flaskUrl = config('services.flask.url', env('FLASK_SERVICE_URL', 'http://face-service:5000'));
 
             try {
-                $listResponse = Http::timeout(5)->get("{$flaskUrl}/face-dataset/{$user->username}");
+                $listResponse = Http::timeout(5)->get("{$flaskUrl}/face-dataset/{$targetUser->username}");
 
                 if ($listResponse->successful()) {
                     $photos = $listResponse->json('photos', []);
@@ -80,10 +89,10 @@ public function update(ProfileUpdateRequest $request): RedirectResponse
                         $photoResponse = Http::timeout(5)->get("{$flaskUrl}{$photoPath}");
 
                         if ($photoResponse->successful()) {
-                            $filename = 'profile/' . $user->username . '_' . time() . '.jpg';
+                            $filename = 'profile/' . $targetUser->username . '_' . time() . '.jpg';
                             Storage::disk('public')->put($filename, $photoResponse->body());
 
-                            $user->update(['foto' => $filename]);
+                            $targetUser->update(['foto' => $filename]);
 
                             return response($photoResponse->body())
                                 ->header('Content-Type', 'image/jpeg')

--- a/laravel-app/app/Models/User.php
+++ b/laravel-app/app/Models/User.php
@@ -67,7 +67,7 @@ class User extends Authenticatable
     /**
      * Get the profile photo URL with hybrid fallback:
      * 1. Manual upload (foto column)
-     * 2. Face dataset proxy (self-caching)
+     * 2. Face dataset proxy (self-caching) — passes user ID so it works in admin context too
      * 3. Default SVG avatar
      */
     public function getProfilePhotoUrlAttribute(): string
@@ -77,7 +77,7 @@ class User extends Authenticatable
         }
 
         if ($this->has_face_data && $this->username) {
-            return route('profile.photo');
+            return route('profile.photo', ['user' => $this->id]);
         }
 
         return asset('img/default-avatar.svg');

--- a/laravel-app/docker/entrypoint.sh
+++ b/laravel-app/docker/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+# Ensure storage directory structure exists
+mkdir -p /var/www/html/storage/app/public/profile
+mkdir -p /var/www/html/storage/framework/{cache,sessions,views}
+mkdir -p /var/www/html/storage/logs
+
+# Fix permissions
+chown -R www-data:www-data /var/www/html/storage /var/www/html/bootstrap/cache
+chmod -R 775 /var/www/html/storage /var/www/html/bootstrap/cache
+
+# Create public/storage symlink (re-create on every startup)
+php artisan storage:link --force 2>/dev/null || true
+
+# Start Apache
+exec apache2-foreground

--- a/laravel-app/resources/views/dashboard.blade.php
+++ b/laravel-app/resources/views/dashboard.blade.php
@@ -59,9 +59,9 @@
         <!-- COMPACT PROFILE HEADER (Gojek/Shopee Style) -->
         <div class="md:hidden flex items-center justify-between mb-6 bg-white dark:bg-card-dark p-4 rounded-2xl shadow-sm border border-slate-200 dark:border-slate-700">
             <div class="flex items-center gap-3">
-                <div class="w-10 h-10 rounded-full bg-primary/30 dark:bg-primary/20 flex items-center justify-center text-slate-900 dark:text-white font-bold border border-primary">
-                    {{ substr(Auth::user()->name, 0, 1) }}
-                </div>
+                <img src="{{ Auth::user()->profile_photo_url }}" alt="{{ Auth::user()->name }}"
+                     class="w-10 h-10 rounded-full object-cover border border-primary"
+                     onerror="this.onerror=null;this.src='{{ asset('img/default-avatar.svg') }}'">
                 <div class="leading-tight">
                     <p class="text-xs text-slate-500 dark:text-slate-400 font-medium">Selamat Pagi,</p>
                     <h2 class="text-sm font-bold text-slate-800 dark:text-white">{{ explode(' ', $user->name)[0] }}</h2>

--- a/laravel-app/resources/views/layouts/absensi.blade.php
+++ b/laravel-app/resources/views/layouts/absensi.blade.php
@@ -205,10 +205,9 @@
         <!-- Sidebar Footer -->
         <div class="p-4 border-t border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-800/50">
             <div class="flex items-center gap-3 mb-3">
-                <div
-                    class="w-10 h-10 rounded-full bg-primary/30 dark:bg-primary/20 flex items-center justify-center text-slate-900 dark:text-white font-bold">
-                    {{ substr(Auth::user()->name, 0, 1) }}
-                </div>
+                <img src="{{ Auth::user()->profile_photo_url }}" alt="{{ Auth::user()->name }}"
+                     class="w-10 h-10 rounded-full object-cover"
+                     onerror="this.onerror=null;this.src='{{ asset('img/default-avatar.svg') }}'">
                 <div class="flex-1 min-w-0">
                     <p class="text-sm font-bold text-slate-900 dark:text-white truncate">{{ Auth::user()->name }}</p>
                     <p class="text-xs text-slate-500 dark:text-slate-400 truncate capitalize">{{ Auth::user()->role }}</p>

--- a/laravel-app/routes/web.php
+++ b/laravel-app/routes/web.php
@@ -45,7 +45,7 @@ Route::middleware(['auth'])->group(function () {
     Route::delete('/profile', [ProfileController::class, 'destroy'])
         ->name('profile.destroy');
 
-    Route::get('/profile/photo', [ProfileController::class, 'photo'])
+    Route::get('/profile/photo/{user?}', [ProfileController::class, 'photo'])
         ->name('profile.photo');
 
     Route::get('/profile/password', [PasswordController::class, 'edit'])


### PR DESCRIPTION
## Summary                                                                                                                                               
     - persist Laravel storage in Docker so uploaded profile photos survive container restarts                                              
     - ensure `storage:link` is recreated on container startup via Docker entrypoint    
     - fix profile photo URL resolution in admin context and render real profile photos in employee dashboard/                                                
     sidebar                                                                                                                     
                                                                                                              
     ## Teammate setup after pull                                                                                
     1. docker compose down                                                                                          
     2. docker compose build laravel                                                                               
     3. docker compose up -d                                                                                             
     4. (optional) docker compose exec laravel php artisan optimize:clear